### PR TITLE
Immediate quizlet contentscript execution

### DIFF
--- a/utils/manifest-plugin.js
+++ b/utils/manifest-plugin.js
@@ -48,6 +48,7 @@ class ManifestCompilationPlugin {
             this.manifest.content_scripts.push({
                 matches,
                 js: [`${name}.content.js`],
+                run_at: name === 'quizlet' ? 'document_start' : 'document_idle',
             });
 
             // Aggiungo informazioni sui permessi


### PR DESCRIPTION
MutationObserver (with the rest of the content script) is instantiated before page load, and as such any new elements which fall under the paywalled nodes are immediately removed and not rendered.